### PR TITLE
Fix #2 to explicitly disallow repeated keys

### DIFF
--- a/examples/dump_yaml.rs
+++ b/examples/dump_yaml.rs
@@ -1,12 +1,11 @@
 extern crate strict_yaml_rust;
 
 use std::env;
-use std::fs::{File, read_to_string};
+use std::fs::read_to_string;
 
-use std::io;
 use strict_yaml_rust::strict_yaml;
 
-pub type Result<T> = ::std::result::Result<T, Box<::std::error::Error>>;
+pub type Result<T> = ::std::result::Result<T, Box<dyn (::std::error::Error)>>;
 
 fn print_indent(indent: usize) {
     for _ in 0..indent {

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -363,7 +363,7 @@ a4:
         let s = r#"
 cataloge:
   product: "&coffee   { name: Coffee,    price: 2.5  ,  unit: 1l  }"
-  product: "&cookies  { name: Cookies!,  price: 3.40 ,  unit: 400g}"
+  product2: "&cookies  { name: Cookies!,  price: 3.40 ,  unit: 400g}"
 
 products:
   *coffee:

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -10,18 +10,7 @@ pub enum EmitError {
     BadHashmapKey,
 }
 
-impl Error for EmitError {
-    fn description(&self) -> &str {
-        match *self {
-            EmitError::FmtError(ref err) => err.description(),
-            EmitError::BadHashmapKey => "bad hashmap key",
-        }
-    }
-
-    fn cause(&self) -> Option<&Error> {
-        None
-    }
-}
+impl Error for EmitError {}
 
 impl Display for EmitError {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -39,7 +28,7 @@ impl From<fmt::Error> for EmitError {
 }
 
 pub struct StrictYamlEmitter<'a> {
-    writer: &'a mut fmt::Write,
+    writer: &'a mut dyn fmt::Write,
     best_indent: usize,
     compact: bool,
 
@@ -49,7 +38,7 @@ pub struct StrictYamlEmitter<'a> {
 pub type EmitResult = Result<(), EmitError>;
 
 // from serialize::json
-fn escape_str(wr: &mut fmt::Write, v: &str) -> Result<(), fmt::Error> {
+fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
     wr.write_str("\"")?;
     let mut start = 0;
 
@@ -111,7 +100,7 @@ fn escape_str(wr: &mut fmt::Write, v: &str) -> Result<(), fmt::Error> {
 }
 
 impl<'a> StrictYamlEmitter<'a> {
-    pub fn new(writer: &'a mut fmt::Write) -> StrictYamlEmitter {
+    pub fn new(writer: &'a mut dyn fmt::Write) -> StrictYamlEmitter {
         StrictYamlEmitter {
             writer,
             best_indent: 2,
@@ -296,12 +285,12 @@ fn need_quotes(string: &str) -> bool {
         | '\"'
         | '\''
         | '\\'
-        | '\0'...'\x06'
+        | '\0'..='\x06'
         | '\t'
         | '\n'
         | '\r'
-        | '\x0e'...'\x1a'
-        | '\x1c'...'\x1f' => true,
+        | '\x0e'..='\x1a'
+        | '\x1c'..='\x1f' => true,
         _ => false,
     })
         || [

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -336,8 +336,6 @@ a4:
             let mut emitter = StrictYamlEmitter::new(&mut writer);
             emitter.dump(doc).unwrap();
         }
-        println!("original:\n{}", s);
-        println!("emitted:\n{}", writer);
         let docs_new = match StrictYamlLoader::load_from_str(&writer) {
             Ok(y) => y,
             Err(e) => panic!(format!("{}", e))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -347,7 +347,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
 
     fn _explict_document_start(&mut self) -> ParseResult {
         self.parser_process_directives()?;
-        match *try!(self.peek_token()) {
+        match *self.peek_token()? {
             Token(mark, TokenType::DocumentStart) => {
                 self.push_state(State::DocumentEnd);
                 self.state = State::DocumentContent;

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -67,7 +67,7 @@ impl Error for ScanError {
         self.info.as_ref()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -183,7 +183,7 @@ fn is_digit(c: char) -> bool {
 #[inline]
 fn is_alpha(c: char) -> bool {
     match c {
-        '0'...'9' | 'a'...'z' | 'A'...'Z' => true,
+        '0'..='9' | 'a'..='z' | 'A'..='Z' => true,
         '_' | '-' => true,
         _ => false,
     }
@@ -195,9 +195,9 @@ fn is_hex(c: char) -> bool {
 #[inline]
 fn as_hex(c: char) -> u32 {
     match c {
-        '0'...'9' => (c as u32) - ('0' as u32),
-        'a'...'f' => (c as u32) - ('a' as u32) + 10,
-        'A'...'F' => (c as u32) - ('A' as u32) + 10,
+        '0'..='9' => (c as u32) - ('0' as u32),
+        'a'..='f' => (c as u32) - ('a' as u32) + 10,
+        'A'..='F' => (c as u32) - ('A' as u32) + 10,
         _ => unreachable!(),
     }
 }

--- a/src/strict_yaml.rs
+++ b/src/strict_yaml.rs
@@ -4,6 +4,8 @@ use std::string;
 use std::str;
 use std::mem;
 use std::vec;
+use std::fmt;
+use std::error::Error;
 use parser::*;
 use scanner::{TScalarStyle, ScanError, Marker};
 use linked_hash_map::LinkedHashMap;
@@ -42,6 +44,21 @@ pub enum StrictYaml {
     BadValue,
 }
 
+#[derive(Clone, PartialEq, Debug, Eq)]
+enum StoreError { RepeatedHashKey }
+
+impl Error for StoreError {}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StoreError::RepeatedHashKey => {
+                write!(formatter, "Key already exists in the hash map")},
+            _ => write!(formatter, "")
+        }
+    }
+}
+
 pub type Array = Vec<StrictYaml>;
 pub type Hash = LinkedHashMap<StrictYaml, StrictYaml>;
 
@@ -55,10 +72,11 @@ pub struct StrictYamlLoader {
 }
 
 impl MarkedEventReceiver for StrictYamlLoader {
-    fn on_event(&mut self, ev: Event, _: Marker) {
+    fn on_event(&mut self, ev: Event, mark: Marker) -> Result<(), ScanError> {
         // println!("EV {:?}", ev);
-        match ev {
+        let res = match ev {
             Event::DocumentStart => {
+                Ok(())
                 // do nothing
             },
             Event::DocumentEnd => {
@@ -68,22 +86,25 @@ impl MarkedEventReceiver for StrictYamlLoader {
                     1 => self.docs.push(self.doc_stack.pop().unwrap().0),
                     _ => unreachable!(),
                 }
+                Ok(())
             }
             Event::SequenceStart(aid) => {
                 self.doc_stack.push((StrictYaml::Array(Vec::new()), aid));
+                Ok(())
             }
             Event::SequenceEnd => {
                 let node = self.doc_stack.pop().unwrap();
-                self.insert_new_node(node);
+                self.insert_new_node(node)
             }
             Event::MappingStart(aid) => {
                 self.doc_stack.push((StrictYaml::Hash(Hash::new()), aid));
                 self.key_stack.push(StrictYaml::BadValue);
+                Ok(())
             }
             Event::MappingEnd => {
                 self.key_stack.pop().unwrap();
                 let node = self.doc_stack.pop().unwrap();
-                self.insert_new_node(node);
+                self.insert_new_node(node)
             }
             Event::Scalar(v, style, aid) => {
                 let node = if style != TScalarStyle::Plain {
@@ -93,17 +114,20 @@ impl MarkedEventReceiver for StrictYamlLoader {
                     StrictYaml::from_str(&v)
                 };
 
-                self.insert_new_node((node, aid));
+                self.insert_new_node((node, aid))
             }
 
-            _ => { /* ignore */ }
-        }
+            _ => { Ok(()) /* ignore */ }
+        };
+        
+        res.map_err(|e| ScanError::new(mark, &format!("Error handling node: {}", e)))
+
         // println!("DOC {:?}", self.doc_stack);
     }
 }
 
 impl StrictYamlLoader {
-    fn insert_new_node(&mut self, node: (StrictYaml, usize)) {
+    fn insert_new_node(&mut self, node: (StrictYaml, usize)) -> Result<(), StoreError> {
         // valid anchor id starts from 1
         if node.1 > 0 {
             self.anchor_map.insert(node.1, node.0.clone());
@@ -112,10 +136,12 @@ impl StrictYamlLoader {
             self.doc_stack.push(node);
         } else {
             let parent = self.doc_stack.last_mut().unwrap();
+            println!("{:?}, {:?}", parent, node);
             match *parent {
                 (StrictYaml::Array(ref mut v), _) => v.push(node.0),
                 (StrictYaml::Hash(ref mut h), _) => {
                     let cur_key = self.key_stack.last_mut().unwrap();
+
                     // current node is a key
                     if cur_key.is_badvalue() {
                         *cur_key = node.0;
@@ -123,12 +149,19 @@ impl StrictYamlLoader {
                     } else {
                         let mut newkey = StrictYaml::BadValue;
                         mem::swap(&mut newkey, cur_key);
-                        h.insert(newkey, node.0);
+
+                        if h.contains_key(&newkey) {
+                            return Err(StoreError::RepeatedHashKey);
+                        } else {
+                            h.insert(newkey, node.0);
+                        }
                     }
                 },
                 _ => unreachable!(),
             }
         }
+
+        Ok(())
     }
 
     pub fn load_from_str(source: &str) -> Result<Vec<StrictYaml>, ScanError>{
@@ -442,6 +475,18 @@ c: ~
         assert_eq!(Some((StrictYaml::String("a".to_owned()), StrictYaml::String("~".to_owned()))), iter.next());
         assert_eq!(Some((StrictYaml::String("c".to_owned()), StrictYaml::String("~".to_owned()))), iter.next());
         assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn test_duplicate_keys() {
+        let s = "
+a: 10
+a: 15
+";
+        let out = StrictYamlLoader::load_from_str(&s);
+        assert!(out.is_err());
+        //assert_eq!(out.err(), Actual error type);
+
     }
 
 }

--- a/src/strict_yaml.rs
+++ b/src/strict_yaml.rs
@@ -54,7 +54,6 @@ impl fmt::Display for StoreError {
         match self {
             StoreError::RepeatedHashKey => {
                 write!(formatter, "Key already exists in the hash map")},
-            _ => write!(formatter, "")
         }
     }
 }
@@ -87,25 +86,25 @@ impl MarkedEventReceiver for StrictYamlLoader {
                     _ => unreachable!(),
                 }
                 Ok(())
-            }
+            },
             Event::SequenceStart(aid) => {
                 self.doc_stack.push((StrictYaml::Array(Vec::new()), aid));
                 Ok(())
-            }
+            },
             Event::SequenceEnd => {
                 let node = self.doc_stack.pop().unwrap();
                 self.insert_new_node(node)
-            }
+            },
             Event::MappingStart(aid) => {
                 self.doc_stack.push((StrictYaml::Hash(Hash::new()), aid));
                 self.key_stack.push(StrictYaml::BadValue);
                 Ok(())
-            }
+            },
             Event::MappingEnd => {
                 self.key_stack.pop().unwrap();
                 let node = self.doc_stack.pop().unwrap();
                 self.insert_new_node(node)
-            }
+            },
             Event::Scalar(v, style, aid) => {
                 let node = if style != TScalarStyle::Plain {
                     StrictYaml::String(v)
@@ -115,8 +114,7 @@ impl MarkedEventReceiver for StrictYamlLoader {
                 };
 
                 self.insert_new_node((node, aid))
-            }
-
+            },
             _ => { Ok(()) /* ignore */ }
         };
         

--- a/src/strict_yaml.rs
+++ b/src/strict_yaml.rs
@@ -134,7 +134,6 @@ impl StrictYamlLoader {
             self.doc_stack.push(node);
         } else {
             let parent = self.doc_stack.last_mut().unwrap();
-            println!("{:?}, {:?}", parent, node);
             match *parent {
                 (StrictYaml::Array(ref mut v), _) => v.push(node.0),
                 (StrictYaml::Hash(ref mut h), _) => {

--- a/src/strict_yaml.rs
+++ b/src/strict_yaml.rs
@@ -107,7 +107,6 @@ impl MarkedEventReceiver for StrictYamlLoader {
             },
             Event::Scalar(v, style, aid) => {
                 let node = if style != TScalarStyle::Plain {
-                    println!("String: {}", v);
                     StrictYaml::String(v)
                 } else {
                     // Datatype is not specified, or unrecognized

--- a/src/strict_yaml.rs
+++ b/src/strict_yaml.rs
@@ -107,6 +107,7 @@ impl MarkedEventReceiver for StrictYamlLoader {
             },
             Event::Scalar(v, style, aid) => {
                 let node = if style != TScalarStyle::Plain {
+                    println!("String: {}", v);
                     StrictYaml::String(v)
                 } else {
                     // Datatype is not specified, or unrecognized
@@ -162,6 +163,7 @@ impl StrictYamlLoader {
     }
 
     pub fn load_from_str(source: &str) -> Result<Vec<StrictYaml>, ScanError>{
+
         let mut loader = StrictYamlLoader {
             docs: Vec::new(),
             doc_stack: Vec::new(),

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -4,7 +4,6 @@ extern crate quickcheck;
 
 use quickcheck::TestResult;
 use strict_yaml_rust::{StrictYaml, StrictYamlLoader, StrictYamlEmitter};
-use std::error::Error;
 
 quickcheck! {
     fn test_check_weird_keys(xs: Vec<String>) -> TestResult {
@@ -14,7 +13,7 @@ quickcheck! {
             emitter.dump(&StrictYaml::Array(xs.into_iter().map(StrictYaml::String).collect())).unwrap();
         }
         if let Err(err) = StrictYamlLoader::load_from_str(&out_str) {
-            return TestResult::error(err.description());
+            return TestResult::error(format!("{}", err));
         }
         TestResult::passed()
     }


### PR DESCRIPTION
It required implementing error handling in the event handlers, which seemed safe enough.

There are a few other points I think where errors should be raised but aren't, but mostly they fail in a safe way unlike #2 .