### PR TITLE
Implement serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ repository = "https://github.com/fralalonde/strict-yaml-rust"
 
 [dependencies]
 linked-hash-map = "0.5"
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"
+serde = { version = "1", features = ["derive"] }
+
+[features]
+serde = ["dep:serde", "linked-hash-map/serde_impl"]

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ all: format test examples lint
 
 # Unit and doc tests
 test:
-	cargo test
+	cargo test --features serde
 
 examples:
 	cargo build --examples

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -27,17 +27,17 @@ impl From<fmt::Error> for EmitError {
 }
 
 pub struct StrictYamlEmitter<'a> {
-    writer: &'a mut dyn fmt::Write,
+    pub(crate) writer: &'a mut dyn fmt::Write,
     best_indent: usize,
     compact: bool,
 
-    level: isize,
+    pub(crate) level: isize,
 }
 
 pub type EmitResult = Result<(), EmitError>;
 
 // from serialize::json
-fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
+pub(crate) fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
     wr.write_str("\"")?;
     let mut start = 0;
 
@@ -132,7 +132,7 @@ impl<'a> StrictYamlEmitter<'a> {
         self.emit_node(doc)
     }
 
-    fn write_indent(&mut self) -> EmitResult {
+    pub(crate) fn write_indent(&mut self) -> EmitResult {
         if self.level <= 0 {
             return Ok(());
         }
@@ -261,7 +261,7 @@ impl<'a> StrictYamlEmitter<'a> {
 /// * When the string is null or ~ (otherwise, it would be considered as a null value);
 /// * When the string looks like a number, such as integers (e.g. 2, 14, etc.), floats (e.g. 2.6, 14.9) and exponential numbers (e.g. 12e7, etc.) (otherwise, it would be treated as a numeric value);
 /// * When the string looks like a date (e.g. 2014-12-31) (otherwise it would be automatically converted into a Unix timestamp).
-fn need_quotes(string: &str) -> bool {
+pub(crate) fn need_quotes(string: &str) -> bool {
     fn need_quotes_spaces(string: &str) -> bool {
         string.starts_with(' ') || string.ends_with(' ')
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,18 @@
 //! let mut out_str = String::new();
 //! let mut emitter = StrictYamlEmitter::new(&mut out_str);
 //! emitter.dump(doc).unwrap(); // dump the YAML object to a String
-//!
 //! ```
+//!
+//! # Serde
+//!
+//! The crate also provides a [`serde`](https://serde.rs) implementation. The functions
+//! in the [`serde`](module@crate::serde) module can be enabled with the `serde` feature flag.
 
 pub mod emitter;
 pub mod parser;
 pub mod scanner;
+#[cfg(feature = "serde")]
+pub mod serde;
 pub mod strict_yaml;
 
 // reexport key APIs

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,0 +1,940 @@
+use crate::{
+    parser::{Event, Parser},
+    serde::error::Error,
+    strict_yaml::StrictYaml,
+};
+use serde::de::{
+    Deserialize, DeserializeSeed, EnumAccess, Error as SerdeError, IntoDeserializer, MapAccess,
+    SeqAccess, Unexpected, VariantAccess, Visitor,
+};
+use std::str::{Chars, FromStr};
+
+/// Deserialize an instance of type `T` from [`StrictYaml`](enum@crate::StrictYaml).
+///
+/// ```
+/// use strict_yaml_rust::{StrictYaml, serde::from_strict_yaml};
+///
+/// let yaml = StrictYaml::Array(
+///     vec![
+///         StrictYaml::String("1".into()),
+///         StrictYaml::String("2".into()),
+///         StrictYaml::String("3".into())
+///     ]
+/// );
+///
+/// assert_eq!(vec![1, 2, 3], from_strict_yaml::<Vec<u16>>(yaml).unwrap());
+/// ```
+pub fn from_strict_yaml<'a, T>(yaml: StrictYaml) -> Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
+    T::deserialize(yaml)
+}
+
+/// A deserializer for the StrictYAML document format.
+pub struct Deserializer<'de> {
+    parser: Parser<Chars<'de>>,
+    // This is used to toggle and keep track of multi-document
+    // deserialization. This is only relevant when deserializing a
+    // sequence because only sequence types can be deserialized
+    // from a StrictYAML stream containing multiple documents.
+    is_root: Option<bool>,
+}
+
+impl<'de> Deserializer<'de> {
+    fn new(input: &'de str, is_root: Option<bool>) -> Self {
+        Deserializer {
+            parser: Parser::new(input.chars()),
+            is_root,
+        }
+    }
+
+    /// See [`from_str_many`](function@crate::serde::from_str_many) for usage
+    /// examples.
+    pub fn from_str_many(input: &'de str) -> Self {
+        Deserializer::new(input, Some(false))
+    }
+
+    /// See [`from_str`](function@crate::serde::from_str) for usage examples.
+    pub fn from_str(input: &'de str) -> Self {
+        Deserializer::new(input, None)
+    }
+}
+
+/// Deserialize multiple StrictYAML documents from the same stream into an
+/// instance of a container `T`.
+///
+/// The function serves as a hint to the deserializer to expect a
+/// multi-document StrictYAML stream and process it accordingly. The hint from
+/// the user is necessary because StrictYAML is not self-describing to the extent
+/// that JSON is when it comes to mapping StrictYaml to the `serde` data model.
+/// The deserializer needs a way to tell the difference between the
+/// following cases when it calls [`serde::Deserializer::deserialize_seq`]:
+///
+/// ```yaml
+/// ---
+/// some: example
+/// data: 100
+/// ---
+/// some: example
+/// data: 200
+/// ---
+/// some: example
+/// data: 300
+/// ```
+///
+/// ```yaml
+/// ---
+/// - some: example
+///   data: 100
+/// - some: example
+///   data: 200
+/// - some: example
+///   data: 300
+/// ```
+///
+/// [`from_str_many`] handles the former case while the latter is the "default
+/// mode" when calling [`from_str`].
+///
+/// # Examples
+///
+/// As described above the [`from_str_many`] function deserializes a YAML stream containing
+/// multiple documents to a container data structure that implements
+/// [`serde::Deserialize`] (such as [`Vec`] or [`VecDeque`](struct@std::collections::VecDeque)).
+///
+///
+/// ```rust
+/// use strict_yaml_rust::serde::from_str_many;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Deployment {
+///     kind: String,
+///     spec: Spec
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct Spec {
+///     replicas: u16,
+///     name: String
+/// }
+///
+/// let yaml = r#"
+/// ---
+/// kind: deployment
+/// spec:
+///   replicas: 5
+///   name: "nginx"
+/// ---
+/// kind: container
+/// spec:
+///   replicas: 1
+///   name: "redis"
+/// ---
+/// kind: deployment
+/// spec:
+///   replicas: 3
+///   name: "webapp"
+/// ...
+/// "#;
+///
+/// let deployments: Vec<Deployment> = from_str_many(yaml).unwrap();
+///
+/// assert!(deployments.len() == 3);
+/// assert!(deployments.first().is_some_and(|d| d.spec.name == "nginx".to_string()));
+/// ```
+pub fn from_str_many<'a, T>(s: &'a str) -> Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = Deserializer::from_str_many(s);
+
+    // Unlike `from_str` this function skips matching the first
+    // events (`StreamStart` and `DocumentStart`) as well as their
+    // respective ends, because in this case handling multi-document
+    // deserialization is shifted to the `deserialize_seq` method instead.
+
+    T::deserialize(&mut deserializer)
+}
+
+/// Deserialize an instance of type `T` from a StrictYAML document.
+///
+/// # Examples
+///
+/// The [`from_str`] function deserializes a data structure that
+/// implements [`serde::Deserialize`] from a StrictYAML document.
+///
+/// ```rust
+/// use strict_yaml_rust::serde::from_str;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Deployment {
+///     kind: String,
+///     spec: Spec
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct Spec {
+///     replicas: u16,
+///     name: String
+/// }
+///
+/// let yaml = r#"
+/// ---
+/// kind: deployment
+/// spec:
+///   replicas: 5
+///   name: nginx
+/// ...
+/// "#;
+///
+/// let deployment: Deployment = from_str(yaml).unwrap();
+///
+/// assert_eq!(deployment.spec.name, "nginx".to_string());
+/// ```
+pub fn from_str<'a, T>(s: &'a str) -> Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = Deserializer::from_str(s);
+
+    // This function expects only a single document inside a
+    // stream. Thus it tries to match the expected end events
+    // from the loader after deserializing the data "in between".
+
+    let (ev, mark) = deserializer.parser.next()?;
+
+    if ev != Event::StreamStart {
+        return Err(Error::from_event(ev, mark, "the start of the stream"));
+    }
+
+    let (ev, _mark) = deserializer.parser.peek()?;
+
+    if *ev == Event::DocumentStart {
+        deserializer.parser.next()?;
+    }
+
+    let res = T::deserialize(&mut deserializer)?;
+
+    let (ev, _mark) = deserializer.parser.peek()?;
+
+    if *ev == Event::DocumentEnd {
+        deserializer.parser.next()?;
+    }
+
+    let (ev, mark) = deserializer.parser.next()?;
+
+    if ev != Event::StreamEnd {
+        return Err(Error::from_event(ev, mark, "the end of the stream"));
+    }
+
+    Ok(res)
+}
+
+impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
+    type Error = Error;
+
+    /// This is only called by custom visitor implementations when
+    /// the target type does not neatly fit into the serde data model.
+    ///
+    /// The `StrictYaml` enum type calls into this method to deserialize
+    /// efficiently by passing a custom visitor, since we know how
+    /// the serde data model types fit into the different variants.
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.peek()?;
+
+        match ev {
+            Event::Scalar(_, _, _) => self.deserialize_str(visitor),
+            Event::SequenceStart(_) => self.deserialize_seq(visitor),
+            Event::MappingStart(_) => self.deserialize_map(visitor),
+            _ => {
+                return Err(Error::from_event(
+                    ev.clone(),
+                    mark.clone(),
+                    "a sequence, map or scalar",
+                ))
+            }
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let boolean = bool::from_str(&value)
+                    .map_err(|_| Error::invalid_value(Unexpected::Str(&value), &"a boolean"))
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_bool(boolean).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = i8::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"an 8-bit signed integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_i8(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = i16::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 16-bit signed integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_i16(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = i32::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 32-bit signed integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_i32(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = i64::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 64-bit signed integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_i64(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = i128::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"an 128-bit signed integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_i128(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = u8::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"an 8-bit unsigned integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_u8(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = u16::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 16-bit unsigned integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_u16(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = u32::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 32-bit unsigned integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_u32(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = u64::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a 64-bit unsigned integer")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_u64(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = u128::from_str_radix(&value, 10)
+                    .map_err(|_| {
+                        Error::invalid_value(
+                            Unexpected::Str(&value),
+                            &"an 128-bit unsigned integer",
+                        )
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_u128(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = f32::from_str(&value)
+                    .map_err(|_| {
+                        Error::invalid_value(
+                            Unexpected::Str(&value),
+                            &"a 32-bit floating point number",
+                        )
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_f32(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let num = f64::from_str(&value)
+                    .map_err(|_| {
+                        Error::invalid_value(
+                            Unexpected::Str(&value),
+                            &"a 64-bit floating point number",
+                        )
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_f64(num).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                let c = char::from_str(&value)
+                    .map_err(|_| {
+                        Error::invalid_value(Unexpected::Str(&value), &"a single character")
+                    })
+                    .map_err(|err| err + mark)?;
+
+                visitor.visit_char(c).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _style, _anchor_id) => {
+                visitor.visit_string(value).map_err(|err: Error| err + mark)
+            }
+            _ => Err(Error::from_event(ev, mark, "a scalar")),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::UnsupportedType("bytes"))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, _mark) = self.parser.peek()?;
+
+        let is_some = match ev {
+            Event::MappingStart(_) | Event::SequenceStart(_) | Event::Scalar(_, _, _) => true,
+            _ => false,
+        };
+
+        if is_some {
+            visitor.visit_some(self)
+        } else {
+            visitor.visit_none()
+        }
+    }
+
+    /// Allow deserializing the unit type from empty scalars.
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, _mark) = self.parser.peek()?;
+
+        if matches!(ev, Event::Scalar(value, _style, _anchor_id) if value.is_empty()) {
+            let _ = self.parser.next()?;
+        }
+
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    /// This method is somewhat special since it needs to handle
+    /// two deserialization modes:
+    /// - deserializing a regular StrictYAML array
+    /// - deserializing a multi-document StrictYAML stream
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        // This is the expected value when multi-document deserialization
+        // is requested, which is driven by the first call into `deserialize_seq`.
+        if self.is_root == Some(false) {
+            self.is_root = Some(true);
+        }
+
+        let (ev, mark) = self.parser.next()?;
+
+        // Match the next event differently depending on the
+        // toggled deserialization mode.
+        // `ArrayAccess` is responsible for disabling this mode
+        // for nested calls into `deserialize_seq` to avoid toggling
+        // unintended behaviour.
+        let value = match ev {
+            Event::SequenceStart(_) => visitor
+                .visit_seq(ArrayAccess::new(self))
+                .map_err(|err: Error| err + mark)?,
+            Event::StreamStart if self.is_root.is_some() => visitor
+                .visit_seq(ArrayAccess::new(self))
+                .map_err(|err: Error| err + mark)?,
+            _ => {
+                if self.is_root.is_some() {
+                    return Err(Error::from_event(ev, mark, "the start of the stream"));
+                } else {
+                    return Err(Error::from_event(ev, mark, "the start of a sequence"));
+                }
+            }
+        };
+
+        if self.is_root == Some(true) {
+            let (ev, mark) = self.parser.next()?;
+
+            if ev != Event::StreamEnd {
+                return Err(Error::from_event(ev, mark, "the end of the stream"));
+            }
+        } else {
+            let (ev, mark) = self.parser.next()?;
+
+            if ev != Event::SequenceEnd {
+                return Err(Error::from_event(ev, mark, "the end of a sequence"));
+            }
+        }
+
+        Ok(value)
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        let value = match ev {
+            Event::MappingStart(_) => visitor
+                .visit_map(HashAccess::new(self))
+                .map_err(|err: Error| err + mark)?,
+            _ => return Err(Error::from_event(ev, mark, "the start of a mapping")),
+        };
+
+        let (ev, _mark) = self.parser.next()?;
+
+        if ev != Event::MappingEnd {
+            Err(Error::from_event(ev, mark, "the end of a mapping"))
+        } else {
+            Ok(value)
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (ev, mark) = self.parser.next()?;
+
+        match ev {
+            Event::Scalar(value, _, _) => visitor
+                .visit_enum(value.into_deserializer())
+                .map_err(|err: Error| err + mark),
+            _ => {
+                let v = visitor
+                    .visit_enum(Enum::new(self))
+                    .map_err(|err: Error| err + mark)?;
+
+                let (ev, mark) = self.parser.next()?;
+
+                if ev != Event::MappingEnd {
+                    Err(Error::from_event(ev, mark, "the end of a mapping"))
+                } else {
+                    Ok(v)
+                }
+            }
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+struct ArrayAccess<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'a, 'de> ArrayAccess<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        Self { de }
+    }
+}
+
+impl<'de, 'a> SeqAccess<'de> for ArrayAccess<'a, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let (ev, mark) = self.de.parser.peek()?;
+
+        // When this instance of `ArrayAccess` is responsible for
+        // deserializing multiple documents, it needs to temporarily
+        // disable this "mode" for nested calls into `deserialize_*`
+        // methods. Otherwise a nested `deserialize_seq` would inherit
+        // this behaviour, but it needs to be scoped to the top-level
+        // sequence.
+        if self.de.is_root == Some(true) {
+            let mut old_is_root = self.de.is_root.take();
+
+            let res = match ev {
+                Event::StreamEnd => Ok(None),
+                Event::DocumentStart => {
+                    let _ = self.de.parser.next()?;
+
+                    let v = seed.deserialize(&mut *self.de).map(Some)?;
+
+                    let (ev, _mark) = self.de.parser.peek()?;
+
+                    if *ev == Event::DocumentEnd {
+                        let _ = self.de.parser.next()?;
+                    }
+
+                    Ok(v)
+                }
+                _ => Err(Error::from_event(
+                    ev.clone(),
+                    *mark,
+                    "the start of a document or the end of the stream",
+                )),
+            };
+
+            // Reset to the old value. It does not need to be set to
+            // `None`, although it would make no difference to process.
+            self.de.is_root = old_is_root.take();
+
+            Ok(res?)
+        } else {
+            match ev {
+                Event::SequenceEnd => Ok(None),
+                _ => seed.deserialize(&mut *self.de).map(Some),
+            }
+        }
+    }
+}
+
+struct HashAccess<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'a, 'de> HashAccess<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        Self { de }
+    }
+}
+
+impl<'de, 'a> MapAccess<'de> for HashAccess<'a, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let (ev, _mark) = self.de.parser.peek()?;
+
+        match ev {
+            Event::MappingEnd => Ok(None),
+            _ => seed.deserialize(&mut *self.de).map(Some),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.de)
+    }
+}
+
+struct Enum<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'a, 'de> Enum<'a, 'de> {
+    fn new(de: &'a mut Deserializer<'de>) -> Self {
+        Self { de }
+    }
+}
+
+impl<'de, 'a> EnumAccess<'de> for Enum<'a, 'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let v = seed.deserialize(&mut *self.de)?;
+        Ok((v, self))
+    }
+}
+
+impl<'de, 'a> VariantAccess<'de> for Enum<'a, 'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.de)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        serde::de::Deserializer::deserialize_seq(self.de, visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        serde::de::Deserializer::deserialize_map(self.de, visitor)
+    }
+}

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -1,0 +1,241 @@
+use crate::{
+    emitter::EmitError,
+    parser::Event,
+    scanner::{Marker, ScanError},
+};
+use std::{fmt, str};
+
+/// An error type that contains all possible error variants that may occur
+/// when serializing or deserializing StrictYaml data.
+#[derive(Debug)]
+pub enum Error {
+    /// Wraps errors that originate from serde.
+    Message(String),
+    /// Enhances errors from serde with a marker to the location where
+    /// the error occured.
+    MarkedMessage { msg: String, mark: Marker },
+    /// Raised when the deserializer calls an unsupported `deserialize_*`
+    /// method based on the input data.
+    UnsupportedType(&'static str),
+    /// Raised when the deserializer expected the start of a YAML stream,
+    /// but encounters something different.
+    UnexpectedStreamStart {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the end of a YAML stream,
+    /// but encounters something different.
+    UnexpectedStreamEnd {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the start of a YAML document,
+    /// but encounters something different.
+    UnexpectedDocumentStart {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the end of a YAML document,
+    /// but encounters something different.
+    UnexpectedDocumentEnd {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected a scalar value, but encounters
+    /// something different.
+    UnexpectedScalar {
+        mark: Marker,
+        expected: &'static str,
+        value: String,
+    },
+    /// Raised when the deserializer expected the start of a YAML sequence,
+    /// but encounters something different.
+    UnexpectedSequenceStart {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the end of a YAML sequence,
+    /// but encounters something different.
+    UnexpectedSequenceEnd {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the start of a YAML map,
+    /// but encounters something different.
+    UnexpectedMappingStart {
+        mark: Marker,
+        expected: &'static str,
+    },
+    /// Raised when the deserializer expected the end of a YAML map,
+    /// but encounters something different.
+    UnexpectedMappingEnd {
+        mark: Marker,
+        expected: &'static str,
+    },
+}
+
+impl Error {
+    /// Construct the appropiate error variant based on the event
+    /// emitted by the parser, wich did not match the event expected
+    /// by the deserializer.
+    pub(crate) fn from_event(ev: Event, mark: Marker, expected: &'static str) -> Self {
+        match ev {
+            Event::StreamStart => Self::UnexpectedStreamStart { mark, expected },
+            Event::StreamEnd => Self::UnexpectedStreamEnd { mark, expected },
+            Event::DocumentStart => Self::UnexpectedDocumentStart { mark, expected },
+            Event::DocumentEnd => Self::UnexpectedDocumentEnd { mark, expected },
+            Event::Scalar(value, _, _) => Self::UnexpectedScalar {
+                mark,
+                expected,
+                value,
+            },
+            Event::SequenceStart(_) => Self::UnexpectedSequenceStart { mark, expected },
+            Event::SequenceEnd => Self::UnexpectedSequenceEnd { mark, expected },
+            Event::MappingStart(_) => Self::UnexpectedMappingStart { mark, expected },
+            Event::MappingEnd => Self::UnexpectedMappingEnd { mark, expected },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::Message(msg.to_string())
+    }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::Message(msg.to_string())
+    }
+}
+
+impl From<ScanError> for Error {
+    fn from(error: ScanError) -> Self {
+        Error::Message(error.to_string())
+    }
+}
+
+impl From<EmitError> for Error {
+    fn from(error: EmitError) -> Self {
+        Error::Message(error.to_string())
+    }
+}
+
+impl From<fmt::Error> for Error {
+    fn from(error: fmt::Error) -> Self {
+        Error::Message(error.to_string())
+    }
+}
+
+impl From<str::Utf8Error> for Error {
+    fn from(error: str::Utf8Error) -> Self {
+        Error::Message(error.to_string())
+    }
+}
+
+impl std::ops::Add<Marker> for Error {
+    type Output = Self;
+
+    /// The `add` operator is overloaded to enhance a serde error
+    /// with a location provided by the parser.
+    fn add(self, mark: Marker) -> Self {
+        match self {
+            Self::Message(msg) => Self::MarkedMessage { msg, mark },
+            _ => self,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Message(msg) => formatter.write_str(msg),
+            Error::MarkedMessage { msg, mark } => {
+                write!(formatter, "{} at line {}", msg, mark.line())
+            }
+            Error::UnsupportedType(t) => {
+                write!(formatter, "(de)serialization of {} is not supported", t)
+            }
+            Error::UnexpectedStreamStart { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the start of the stream at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedStreamEnd { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the end of the stream at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedDocumentStart { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the start of a document at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedDocumentEnd { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the end of a document at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedScalar {
+                mark,
+                expected,
+                value,
+            } => {
+                write!(
+                    formatter,
+                    "expected {}, but found scalar \"{}\" at line {}",
+                    expected,
+                    value,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedSequenceStart { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the start of a sequence at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedSequenceEnd { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the end of a sequence at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedMappingStart { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the start of a mapping at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+            Error::UnexpectedMappingEnd { mark, expected } => {
+                write!(
+                    formatter,
+                    "expected {}, but found the end of a mapping at line {}",
+                    expected,
+                    mark.line()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,0 +1,700 @@
+//! This module provides a [`serde`] implementation.
+//!
+//! The functions in this module can be used to serialize data
+//! structures to StrictYAML and deserialize a data structure from
+//! a StrictYAML document stream.
+
+pub mod de;
+pub mod error;
+pub mod ser;
+
+pub use de::from_str;
+pub use de::from_str_many;
+pub use de::from_strict_yaml;
+pub use ser::to_strict_yaml;
+pub use ser::to_string;
+pub use ser::to_string_many;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::strict_yaml::StrictYaml;
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn test_primitive_de_ser() {
+        let input = r#"---
+|
+  foo
+  bar
+"#;
+
+        let expected = "foo\nbar\n".to_string();
+
+        assert_eq!(expected, from_str::<String>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+
+        let input = r#"---
+"true"
+"#;
+
+        assert_eq!(true, from_str(input).unwrap());
+        assert_eq!(input, to_string(&true).unwrap());
+
+        let input = r#"---
+"false"
+"#;
+
+        assert_eq!(false, from_str(input).unwrap());
+        assert_eq!(input, to_string(&false).unwrap());
+
+        let input = r#"---
+foobar
+"#;
+
+        assert_eq!("foobar".to_string(), from_str::<String>(input).unwrap());
+        assert_eq!(input, to_string(&"foobar").unwrap());
+
+        let input = r#"---
+"78"
+"#;
+
+        assert_eq!(78, from_str(input).unwrap());
+        assert_eq!(input, to_string(&78).unwrap());
+
+        let input = r#"---
+"-78"
+"#;
+
+        assert_eq!(-78, from_str(input).unwrap());
+        assert_eq!(input, to_string(&-78).unwrap());
+
+        let input = r#"---
+"7.8"
+"#;
+
+        assert_eq!(7.8, from_str(input).unwrap());
+        assert_eq!(input, to_string(&7.8).unwrap());
+
+        let input = r#"---
+"-7.8"
+"#;
+
+        assert_eq!(-7.8, from_str(input).unwrap());
+        assert_eq!(input, to_string(&-7.8).unwrap());
+
+        let input = r#"---
+"%"
+"#;
+
+        assert_eq!('%', from_str(input).unwrap());
+        assert_eq!(input, to_string(&'%').unwrap());
+    }
+
+    #[test]
+    fn test_option_de_ser() {
+        let input = r#"---
+foobar
+"#;
+
+        let expected = Some("foobar".to_string());
+
+        assert_eq!(expected, from_str::<Option<String>>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_unit_de_ser() {
+        assert_eq!((), from_str("").unwrap());
+
+        let input = r#"---
+"#;
+
+        assert_eq!((), from_str(input).unwrap());
+        assert_eq!(input, to_string(&()).unwrap());
+    }
+
+    #[test]
+    fn test_unit_struct_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Test;
+
+        let input = r#"---
+"#;
+
+        assert_eq!(Test, from_str(input).unwrap());
+        assert_eq!(input, to_string(&Test).unwrap());
+    }
+
+    #[test]
+    fn test_newtype_struct_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Test(String);
+
+        let input = r#"---
+foobar
+"#;
+
+        let expected = Test("foobar".to_string());
+
+        assert_eq!(expected, from_str(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_vec_de_ser() {
+        let input = r#"---
+- foo
+- bar
+- foobar
+"#;
+
+        let expected = vec!["foo", "bar", "foobar"];
+
+        assert_eq!(expected, from_str::<Vec<String>>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_tuple_de_ser() {
+        let input = r#"---
+- foobar
+- "false"
+- "8"
+"#;
+
+        let expected = ("foobar".to_string(), false, 8);
+
+        assert_eq!(expected, from_str::<(String, bool, u8)>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_tuple_struct_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Test(String, bool, u8);
+
+        let input = r#"---
+- foobar
+- "false"
+- "8"
+"#;
+
+        let expected = Test("foobar".to_string(), false, 8);
+
+        assert_eq!(expected, from_str(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_struct_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct Test {
+            a: String,
+            b: usize,
+            c: bool,
+            d: u8,
+        }
+
+        let input = r#"---
+a: foo
+b: "50"
+c: "true"
+d: "2"
+"#;
+
+        let expected = Test {
+            a: "foo".to_string(),
+            b: 50,
+            c: true,
+            d: 2,
+        };
+
+        assert_eq!(expected, from_str::<Test>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_complex_struct_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Test {
+            a: bool,
+            b: Vec<Item>,
+            c: (u8, u8, bool),
+            d: Sub,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Item {
+            foo: String,
+            bar: f64,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct Sub {
+            x: bool,
+            y: String,
+            z: i64,
+        }
+
+        let input = r#"---
+a: "false"
+b:
+  - foo: some value
+    bar: "100.1234"
+  - foo: other value
+    bar: "101.1234"
+  - foo: final value
+    bar: "102.1234"
+c:
+  - "10"
+  - "12"
+  - "false"
+d:
+  x: "false"
+  y: |
+    foo
+    bar
+  z: "6"
+"#;
+
+        let expected = Test {
+            a: false,
+            b: vec![
+                Item {
+                    foo: "some value".to_string(),
+                    bar: 100.1234,
+                },
+                Item {
+                    foo: "other value".to_string(),
+                    bar: 101.1234,
+                },
+                Item {
+                    foo: "final value".to_string(),
+                    bar: 102.1234,
+                },
+            ],
+            c: (10, 12, false),
+            d: Sub {
+                z: 6,
+                x: false,
+                y: "foo\nbar\n".to_string(),
+            },
+        };
+
+        assert_eq!(expected, from_str(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_enum_struct_variant_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct TestStruct {
+            first: TestEnum,
+            second: Vec<TestEnum>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum TestEnum {
+            #[serde(rename = "a")]
+            A {
+                b: usize,
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                c: Option<bool>,
+                d: Vec<u8>,
+            },
+        }
+
+        let input = r#"---
+first:
+  a:
+    b: "50"
+    c: "true"
+    d:
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+second:
+  - a:
+      b: "50"
+      d:
+        - "1"
+        - "2"
+  - a:
+      b: "50"
+      c: "false"
+      d:
+        - "1"
+        - "2"
+"#;
+
+        let expected = TestStruct {
+            first: TestEnum::A {
+                b: 50,
+                c: Some(true),
+                d: vec![1, 2, 3, 4],
+            },
+            second: vec![
+                TestEnum::A {
+                    b: 50,
+                    c: None,
+                    d: vec![1, 2],
+                },
+                TestEnum::A {
+                    b: 50,
+                    c: Some(false),
+                    d: vec![1, 2],
+                },
+            ],
+        };
+
+        assert_eq!(expected, from_str::<TestStruct>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_enum_newtype_variant_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        struct TestStruct {
+            first: TestEnum,
+            second: Vec<TestEnum>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum TestEnum {
+            #[serde(rename = "a")]
+            A(Vec<u8>),
+            B(String),
+        }
+
+        let input = r#"---
+first:
+  a:
+    - "1"
+    - "2"
+second:
+  - B: |
+      foo
+      bar
+  - a:
+      - "3"
+      - "4"
+      - "5"
+      - "6"
+  - B: "true"
+"#;
+
+        let expected = TestStruct {
+            first: TestEnum::A(vec![1, 2]),
+            second: vec![
+                TestEnum::B("foo\nbar\n".to_string()),
+                TestEnum::A(vec![3, 4, 5, 6]),
+                TestEnum::B("true".to_string()),
+            ],
+        };
+
+        assert_eq!(expected, from_str::<TestStruct>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_enum_tuple_variant_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum Test {
+            #[serde(rename = "a")]
+            A(u8, bool, String),
+        }
+
+        let input = r#"---
+a:
+  - "1"
+  - "true"
+  - foobar
+"#;
+
+        let expected = Test::A(1, true, "foobar".to_string());
+
+        assert_eq!(expected, from_str::<Test>(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_enum_unit_variant_de_ser() {
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum Test {
+            First,
+            Second,
+        }
+
+        let input = r#"---
+First
+"#;
+
+        assert_eq!(Test::First, from_str(input).unwrap());
+        assert_eq!(input, to_string(&Test::First).unwrap());
+
+        let input = r#"---
+First
+---
+Second
+"#;
+
+        let expected = vec![Test::First, Test::Second];
+
+        assert_eq!(expected, from_str_many::<Vec<Test>>(input).unwrap());
+        assert_eq!(input, to_string_many(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_map_de_ser() {
+        let input = r#"---
+a: |
+  foo
+  bar
+  baz
+b: "50"
+c: "true"
+d: "2"
+"#;
+
+        let yaml = from_str::<StrictYaml>(input).unwrap();
+
+        assert_eq!(input, to_string(&yaml).unwrap());
+    }
+
+    #[test]
+    fn test_array_de_ser() {
+        let input = r#"---
+- foo
+- "50"
+- "true"
+- "2"
+"#;
+
+        let yaml = from_str::<StrictYaml>(input).unwrap();
+
+        assert_eq!(input, to_string(&yaml).unwrap());
+    }
+
+    #[test]
+    fn test_complex_de_ser() {
+        let input = r#"---
+a:
+  b:
+    c: hello
+  d: "{}"
+e:
+  - f
+  - g
+  - h: "[]"
+    d: "10"
+  - a:
+      - b
+      - c
+    d: e
+c: b
+"#;
+
+        let yaml = from_str::<StrictYaml>(input).unwrap();
+
+        assert_eq!(input, to_string(&yaml).unwrap());
+    }
+
+    #[test]
+    fn test_nested_map_de_ser() {
+        let input = r#"---
+a:
+  b:
+    c:
+      d:
+        e: f
+"#;
+
+        let yaml = from_str::<StrictYaml>(input).unwrap();
+
+        assert_eq!(input, to_string(&yaml).unwrap());
+    }
+
+    #[test]
+    fn test_nested_array_de_ser() {
+        let input = r#"---
+a:
+  - b
+  - - c
+    - d
+    - - e
+      - - f
+      - - e
+"#;
+
+        let yaml = from_str::<StrictYaml>(input).unwrap();
+
+        assert_eq!(input, to_string(&yaml).unwrap());
+    }
+
+    #[test]
+    fn test_enum_struct_deeply_nested_de_ser() {
+        use std::{collections::HashMap, default::Default};
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct Deployment {
+            #[serde(rename = "apiVersion")]
+            api_version: String,
+            kind: Kind,
+            metadata: Metadata,
+            spec: DeploymentSpec,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum Kind {
+            Deployment,
+            StatefulSet,
+            DaemonSet,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct Metadata {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            name: Option<String>,
+            labels: HashMap<String, String>,
+            #[serde(default, skip_serializing)]
+            iteration: usize,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct DeploymentSpec {
+            #[serde(default)]
+            replicas: usize,
+            selector: Selector,
+            template: Template,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum Selector {
+            #[serde(rename = "matchLabels")]
+            ByLabel(HashMap<String, String>),
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct Template {
+            metadata: Metadata,
+            spec: ContainerSpec,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct ContainerSpec {
+            containers: Vec<Container>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[serde(deny_unknown_fields)]
+        struct Container {
+            name: String,
+            image: String,
+            ports: Vec<Port>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        enum Port {
+            #[serde(rename = "containerPort")]
+            ContainerPort(usize),
+        }
+
+        let input = r#"---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: "3"
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: "nginx:1.14.2"
+          ports:
+            - containerPort: "80"
+            - containerPort: "443"
+"#;
+
+        let expected = Deployment {
+            api_version: "apps/v1".to_string(),
+            kind: Kind::Deployment,
+            metadata: Metadata {
+                name: Some("nginx-deployment".to_string()),
+                labels: HashMap::from([("app".to_string(), "nginx".to_string())]),
+                iteration: Default::default(),
+            },
+            spec: DeploymentSpec {
+                replicas: 3,
+                selector: Selector::ByLabel(HashMap::from([(
+                    "app".to_string(),
+                    "nginx".to_string(),
+                )])),
+                template: Template {
+                    metadata: Metadata {
+                        name: None,
+                        labels: HashMap::from([("app".to_string(), "nginx".to_string())]),
+                        iteration: Default::default(),
+                    },
+                    spec: ContainerSpec {
+                        containers: vec![Container {
+                            name: "nginx".to_string(),
+                            image: "nginx:1.14.2".to_string(),
+                            ports: vec![Port::ContainerPort(80), Port::ContainerPort(443)],
+                        }],
+                    },
+                },
+            },
+        };
+
+        assert_eq!(expected, from_str(input).unwrap());
+        assert_eq!(input, to_string(&expected).unwrap());
+    }
+
+    #[test]
+    fn test_document_stream_de_ser() {
+        let input = r#"---
+a: foo
+b:
+  - |
+      test
+  - "true"
+  - - "1"
+    - "2"
+c: "true"
+---
+- a
+- b:
+    c:
+      d: e
+      f:
+        - "true"
+        - |
+            1
+            2
+- foobar
+---
+the end
+"#;
+
+        let yaml = from_str_many::<Vec<StrictYaml>>(input).unwrap();
+
+        assert_eq!(input, to_string_many(&yaml).unwrap());
+    }
+}

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,0 +1,869 @@
+use crate::{
+    emitter::{escape_str, need_quotes, StrictYamlEmitter},
+    serde::error::Error,
+    strict_yaml::{self, StrictYaml},
+};
+use serde::ser::{
+    self, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+};
+use std::fmt;
+
+/// Serialize an instance of type `T` to [`StrictYaml`](enum@crate::StrictYaml).
+///
+/// ```
+/// use strict_yaml_rust::{StrictYaml, serde::to_strict_yaml};
+///
+/// let v = vec![1, 2, 3];
+///
+/// let yaml = StrictYaml::Array(
+///     vec![
+///         StrictYaml::String("1".into()),
+///         StrictYaml::String("2".into()),
+///         StrictYaml::String("3".into())
+///     ]
+/// );
+///
+/// assert_eq!(yaml, to_strict_yaml(v).unwrap());
+/// ```
+pub fn to_strict_yaml<T: Serialize>(value: T) -> Result<StrictYaml, Error> {
+    value.serialize(strict_yaml::serde::ser::Serializer)
+}
+
+/// Serialize an instance of type `T` to a StrictYAML document.
+///
+/// # Examples
+///
+/// The [`to_string`] function serializes a data structure that
+/// implements [`serde::Serialize`] to a StrictYAML document.
+///
+/// ```rust
+/// use strict_yaml_rust::serde::to_string;
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Deployment {
+///     kind: &'static str,
+///     spec: Spec
+/// }
+///
+/// #[derive(Serialize)]
+/// struct Spec {
+///     replicas: u16,
+///     name: &'static str
+/// }
+///
+/// let deployment = Deployment {
+///     kind: "deployment",
+///     spec: Spec {
+///         replicas: 5,
+///         name: "nginx"
+///     }
+/// };
+///
+/// let output = r#"---
+/// kind: deployment
+/// spec:
+///   replicas: "5"
+///   name: nginx
+/// "#;
+///
+/// assert_eq!(output, to_string(&deployment).unwrap());
+/// ```
+pub fn to_string<T>(value: &T) -> Result<String, Error>
+where
+    T: Serialize,
+{
+    let mut out = String::new();
+
+    let mut serializer = Serializer {
+        emitter: StrictYamlEmitter::new(&mut out),
+        scope: None,
+    };
+
+    write!(serializer.emitter.writer, "---")?;
+    writeln!(serializer.emitter.writer)?;
+
+    value.serialize(&mut serializer)?;
+
+    Ok(out)
+}
+
+/// Serialize a container of type `T` to a StrictYAML document stream.
+///
+/// Similar to the deserialization function [`from_str_many`](function@crate::serde::from_str_many)
+/// this function serves as a hint to the serializer to serialize a
+/// container that implements [`serde::Serialize`] (such as [`Vec`] or
+/// [`VecDeque`](struct@std::collections::VecDeque) to a StrictYAML document stream.
+///
+/// In contrast [`to_string`] would serialize such a data structure to a single
+/// StrictYAML document containing an array at the root.
+///
+/// # Examples
+///
+/// As described above the [`to_string_many`] function serializes a
+/// data structure to a StrictYAML document stream containing multiple documents.
+///
+/// ```rust
+/// use strict_yaml_rust::serde::to_string_many;
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Deployment {
+///     kind: &'static str,
+///     spec: Spec
+/// }
+///
+/// #[derive(Serialize)]
+/// struct Spec {
+///     replicas: u16,
+///     name: &'static str
+/// }
+///
+/// let output = r#"---
+/// kind: deployment
+/// spec:
+///   replicas: "5"
+///   name: nginx
+/// ---
+/// kind: container
+/// spec:
+///   replicas: "1"
+///   name: redis
+/// ---
+/// kind: deployment
+/// spec:
+///   replicas: "3"
+///   name: webapp
+/// "#;
+///
+/// let deployments = vec![
+///     Deployment {
+///         kind: "deployment",
+///         spec: Spec {
+///             replicas: 5,
+///             name: "nginx"
+///         }
+///     },
+///     Deployment {
+///         kind: "container",
+///         spec: Spec {
+///             replicas: 1,
+///             name: "redis"
+///         }
+///     },
+///     Deployment {
+///         kind: "deployment",
+///         spec: Spec {
+///             replicas: 3,
+///             name: "webapp"
+///         }
+///     },
+/// ];
+///
+/// assert_eq!(output, to_string_many(&deployments).unwrap());
+/// ```
+pub fn to_string_many<T>(value: &T) -> Result<String, Error>
+where
+    T: Serialize,
+{
+    let mut out = String::new();
+
+    let mut serializer = Serializer {
+        emitter: StrictYamlEmitter::new(&mut out),
+        scope: Some(Scope::Root),
+    };
+
+    value.serialize(&mut serializer)?;
+
+    Ok(out)
+}
+
+#[derive(Debug, PartialEq)]
+enum Scope {
+    Root,
+    Key,
+    Map,
+    Seq,
+}
+
+/// A serializer for the StrictYAML document format.
+pub struct Serializer<'a> {
+    emitter: StrictYamlEmitter<'a>,
+    // This attribute is used to keep track of the parent
+    // node type in contexts where the parent node
+    // type affects serialization of the currently
+    // processed child node.
+    // For example a map is serialized differently
+    // when it is a value inside another map or an
+    // item in a sequence.
+    scope: Option<Scope>,
+}
+
+/// This function is used to serialize any kind of scalar types that are
+/// available in the serde data model.
+/// However there is some nuance to different types, e.g. a string might
+/// contain newlines which should be serialized as a multi-line YAML string,
+/// which also affects indentation.
+/// At the same time numeric types are exclusively single-line.
+///
+/// This function uses the quoting rules from `StrictYamlEmitter`.
+///
+/// It also writes a newline after serializing a scalar, except when the
+/// scalar is a map key, which might be followed by a scalar value on the
+/// same line.
+fn write_str<T: fmt::Display>(
+    serializer: &mut Serializer,
+    v: T,
+    maybe_multi_line: bool,
+) -> Result<(), Error> {
+    let s = v.to_string();
+
+    if serializer.scope == Some(Scope::Key) {
+        serializer.emitter.writer.write_char(' ')?;
+    }
+
+    if maybe_multi_line && s.ends_with('\n') {
+        serializer.emitter.writer.write_char('|')?;
+        writeln!(serializer.emitter.writer)?;
+
+        // Indentation differs for multi-line strings depending
+        // on the context.
+        let level_delta = if serializer.emitter.level < 0 || serializer.scope == Some(Scope::Seq) {
+            2
+        } else {
+            1
+        };
+
+        serializer.emitter.level += level_delta;
+
+        for line in s.lines() {
+            serializer.emitter.write_indent()?;
+            serializer.emitter.writer.write_str(line)?;
+            writeln!(serializer.emitter.writer)?;
+        }
+
+        serializer.emitter.level -= level_delta;
+    } else {
+        if need_quotes(&s) {
+            escape_str(serializer.emitter.writer, &s)?;
+        } else {
+            serializer.emitter.writer.write_str(&s)?;
+        }
+
+        // This scope is set when the scalar is a map key
+        // in which case it may be followed by a scalar value
+        // on the same line and the newline is skipped.
+        if serializer.scope != Some(Scope::Map) {
+            writeln!(serializer.emitter.writer)?;
+        }
+    }
+
+    Ok(())
+}
+
+impl ser::Serializer for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    // Since no extra state is needed to keep track of the
+    // serialization process, `Serializer` can implement every
+    // specified trait.
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, false)
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        write_str(&mut *self, v, true)
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        let s = std::str::from_utf8(v)?;
+
+        write_str(&mut *self, s, true)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        variant.serialize(self)
+    }
+
+    /// Newtype structs are serialized by serializing the inner
+    /// value and ignoring the wrapper.
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    /// Newtype enums are serialized as maps, i.e. `key: value`, where
+    /// `variant` is the key and the value is any type that implements
+    /// `Serialize`.
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        // Start with a newline if the newtype enum is a nested value
+        // inside a map with a given key.
+        if self.scope == Some(Scope::Key) {
+            writeln!(self.emitter.writer)?;
+        }
+
+        self.emitter.level += 1;
+
+        // Skip indentation if the newtype enum is nested inside a
+        // sequence and the key/variant follows a dash `-`.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        }
+
+        // Serialize the variant as if it were a key in a regular
+        // map.
+        let mut old_scope = self.scope.replace(Scope::Map);
+        variant.serialize(&mut *self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        // Serialize the value as if it were a value in a regular
+        // map following a key.
+        old_scope = self.scope.replace(Scope::Key);
+        let v = value.serialize(&mut *self)?;
+        self.scope = old_scope.take();
+
+        self.emitter.level -= 1;
+
+        Ok(v)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        // Unless the values in the sequence are serialized as
+        // multiple documents (as indicated by `self.scope`), empty
+        // sequences are serialized inline with empty brackets.
+        if self.scope != Some(Scope::Root) {
+            if len == Some(0) {
+                write!(self.emitter.writer, "[]")?;
+            } else {
+                self.emitter.level += 1;
+            }
+        }
+
+        // A newline must come before a sequence when the sequence
+        // follows a map key. In contrast a sequence that is nested in
+        // another sequence is started on the same line following the dash `-`.
+        if self.scope == Some(Scope::Key) {
+            writeln!(self.emitter.writer)?;
+        }
+
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    /// Tuple variant enums are serialized as maps, i.e. `key: value`,
+    /// where `variant` is the key and the value is a sequence.
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        // Start with a newline if the tuple variant is a nested value
+        // inside a map with a given key.
+        if self.scope == Some(Scope::Key) {
+            writeln!(self.emitter.writer)?;
+        }
+
+        self.emitter.level += 1;
+
+        // Skip indentation if the tuple variant is nested inside a
+        // sequence and the key/variant follows a dash `-`.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        }
+
+        // Serialize the variant as if it were a key in a regular
+        // map.
+        let mut old_scope = self.scope.replace(Scope::Map);
+        variant.serialize(&mut *self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        self.scope.replace(Scope::Key);
+
+        // Serialize the tuple as if it were a value in a regular
+        // map following a key.
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        if len == Some(0) {
+            write!(self.emitter.writer, "{{}}")?;
+        } else {
+            self.emitter.level += 1;
+        }
+
+        // When the map is nested inside another map the preceding
+        // key must first be followed by a newline.
+        if self.scope == Some(Scope::Key) {
+            writeln!(self.emitter.writer)?;
+        }
+
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        // Start with a newline if the tuple variant is a nested value
+        // inside a map with a given key.
+        if self.scope == Some(Scope::Key) {
+            writeln!(self.emitter.writer)?;
+        }
+
+        self.emitter.level += 1;
+
+        // Skip indentation if the tuple variant is nested inside a
+        // sequence and the key/variant follows a dash `-`.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        }
+
+        // Serialize the variant as if it were a key in a regular
+        // map.
+        let mut old_scope = self.scope.replace(Scope::Map);
+        variant.serialize(&mut *self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        self.scope.replace(Scope::Key);
+
+        // Serialize the value as a nested map following a key from
+        // the parent map.
+        self.serialize_map(Some(len))
+    }
+}
+
+impl SerializeSeq for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // The `Root` scope indicates to the serializer that the sequence
+        // is to be serialized as a multi-line StrictYAML stream.
+        // As such each element is preceded by document delimiters.
+        if self.scope == Some(Scope::Root) {
+            write!(self.emitter.writer, "---")?;
+            writeln!(self.emitter.writer)?;
+
+            let mut old_scope = self.scope.take();
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        } else {
+            // Otherwise the sequence is serialized in a regular manner.
+            // Indentation is skipped for this element if it is the
+            // first element from a sequence nested in another sequence.
+            if self.scope != Some(Scope::Seq) {
+                self.emitter.write_indent()?;
+            } else {
+                self.scope = None;
+            }
+
+            write!(self.emitter.writer, "- ")?;
+
+            let mut old_scope = self.scope.replace(Scope::Seq);
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+
+        if self.scope == Some(Scope::Root) {
+            self.scope = None;
+        }
+
+        Ok(())
+    }
+}
+
+impl SerializeTuple for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // The `Root` scope indicates to the serializer that the sequence
+        // is to be serialized as a multi-line StrictYAML stream.
+        // As such each element is preceded by document delimiters.
+        if self.scope == Some(Scope::Root) {
+            write!(self.emitter.writer, "---")?;
+            writeln!(self.emitter.writer)?;
+
+            let mut old_scope = self.scope.take();
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        } else {
+            // Otherwise the sequence is serialized in a regular manner.
+            // Indentation is skipped for this element if it is the
+            // first element from a sequence nested in another sequence.
+            if self.scope != Some(Scope::Seq) {
+                self.emitter.write_indent()?;
+            } else {
+                self.scope = None;
+            }
+
+            write!(self.emitter.writer, "- ")?;
+
+            let mut old_scope = self.scope.replace(Scope::Seq);
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+
+        if self.scope == Some(Scope::Root) {
+            self.scope = None;
+        }
+
+        Ok(())
+    }
+}
+
+impl SerializeTupleStruct for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // The `Root` scope indicates to the serializer that the sequence
+        // is to be serialized as a multi-line StrictYAML stream.
+        // As such each element is preceded by document delimiters.
+        if self.scope == Some(Scope::Root) {
+            write!(self.emitter.writer, "---")?;
+            writeln!(self.emitter.writer)?;
+
+            let mut old_scope = self.scope.take();
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        } else {
+            // Otherwise the sequence is serialized in a regular manner.
+            // Indentation is skipped for this element if it is the
+            // first element from a sequence nested in another sequence.
+            if self.scope != Some(Scope::Seq) {
+                self.emitter.write_indent()?;
+            } else {
+                self.scope = None;
+            }
+
+            write!(self.emitter.writer, "- ")?;
+
+            let mut old_scope = self.scope.replace(Scope::Seq);
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+
+        if self.scope == Some(Scope::Root) {
+            self.scope = None;
+        }
+
+        Ok(())
+    }
+}
+
+impl SerializeTupleVariant for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // The `Root` scope indicates to the serializer that the sequence
+        // is to be serialized as a multi-line StrictYAML stream.
+        // As such each element is preceded by document delimiters.
+        if self.scope == Some(Scope::Root) {
+            write!(self.emitter.writer, "---")?;
+            writeln!(self.emitter.writer)?;
+
+            let mut old_scope = self.scope.take();
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        } else {
+            // Otherwise the sequence is serialized in a regular manner.
+            // Indentation is skipped for this element if it is the
+            // first element from a sequence nested in another sequence.
+            if self.scope != Some(Scope::Seq) {
+                self.emitter.write_indent()?;
+            } else {
+                self.scope = None;
+            }
+
+            write!(self.emitter.writer, "- ")?;
+
+            let mut old_scope = self.scope.replace(Scope::Seq);
+            value.serialize(&mut **self)?;
+            self.scope = old_scope.take();
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+
+        if self.scope == Some(Scope::Root) {
+            self.scope = None;
+        }
+
+        Ok(())
+    }
+}
+
+impl SerializeMap for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // Skip the indentation if this key is the first in a nested map
+        // inside a sequence, to follow the dash `-` directly.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        } else {
+            self.scope = None;
+        }
+
+        let mut old_scope = self.scope.replace(Scope::Map);
+        key.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let mut old_scope = self.scope.replace(Scope::Key);
+        value.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+        Ok(())
+    }
+}
+
+impl SerializeStruct for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // Skip the indentation if this key is the first in a nested map
+        // inside a sequence, to follow the dash `-` directly.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        } else {
+            self.scope = None;
+        }
+
+        let mut old_scope = self.scope.replace(Scope::Map);
+        key.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        old_scope = self.scope.replace(Scope::Key);
+        value.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.emitter.level -= 1;
+        Ok(())
+    }
+}
+
+impl SerializeStructVariant for &'_ mut Serializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        // Skip the indentation if this key is the first in a nested map
+        // inside a sequence, to follow the dash `-` directly.
+        if self.scope != Some(Scope::Seq) {
+            self.emitter.write_indent()?;
+        } else {
+            self.scope = None;
+        }
+
+        let mut old_scope = self.scope.replace(Scope::Map);
+        key.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+
+        write!(self.emitter.writer, ":")?;
+
+        old_scope = self.scope.replace(Scope::Key);
+        value.serialize(&mut **self)?;
+        self.scope = old_scope.take();
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        // After serializing a struct variant the indentation level
+        // needs to decrease by two, because the level is increased
+        // twice during the process:
+        // - before the key (variant) is serialized
+        // - after the method calls into `serialize_map` to serialize
+        //   its fields
+        self.emitter.level -= 2;
+        Ok(())
+    }
+}

--- a/src/strict_yaml/mod.rs
+++ b/src/strict_yaml/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+pub(crate) mod serde;
+
 use crate::parser::*;
 use crate::scanner::{Marker, ScanError, TScalarStyle};
 use linked_hash_map::LinkedHashMap;
@@ -25,6 +28,7 @@ use std::vec;
 /// }
 /// ```
 #[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize), serde(untagged))]
 pub enum StrictYaml {
     /// YAML scalar.
     String(String),

--- a/src/strict_yaml/serde/de.rs
+++ b/src/strict_yaml/serde/de.rs
@@ -1,0 +1,788 @@
+use crate::{
+    serde::error::Error,
+    strict_yaml::{Hash, StrictYaml},
+};
+use serde::de::{
+    value::StringDeserializer, Deserialize, DeserializeSeed, Deserializer, EnumAccess,
+    Error as SerdeError, IntoDeserializer, MapAccess, SeqAccess, Unexpected, VariantAccess,
+    Visitor,
+};
+use std::{fmt, str::FromStr, vec};
+
+macro_rules! deserialize_number {
+    { $f:ident, $v:ident, $t:ty, $err:literal } => {
+        fn $f<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self {
+                Self::String(value) => {
+                    let num = <$t>::from_str_radix(&value, 10).map_err(|_| {
+                        Self::Error::invalid_value(
+                            Unexpected::Str(&value),
+                            &$err,
+                        )
+                    })?;
+                    visitor.$v(num)
+                }
+                Self::Array(_) => Err(Self::Error::invalid_type(
+                    Unexpected::Seq,
+                    &$err,
+                )),
+                Self::Hash(_) => Err(Self::Error::invalid_type(
+                    Unexpected::Map,
+                    &$err,
+                )),
+                _ => unreachable!(),
+            }
+        }
+    };
+}
+
+macro_rules! deserialize_from_str {
+    { $f:ident, $v:ident, $t:ty, $err:literal } => {
+        fn $f<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self {
+                Self::String(value) => {
+                    let v = <$t>::from_str(&value).map_err(|_| {
+                        Self::Error::invalid_value(
+                            Unexpected::Str(&value),
+                            &$err,
+                        )
+                    })?;
+                    visitor.$v(v)
+                }
+                Self::Array(_) => Err(Self::Error::invalid_type(
+                    Unexpected::Seq,
+                    &$err,
+                )),
+                Self::Hash(_) => Err(Self::Error::invalid_type(
+                    Unexpected::Map,
+                    &$err,
+                )),
+                _ => unreachable!(),
+            }
+        }
+    };
+}
+
+impl<'de> serde::de::Deserializer<'de> for StrictYaml {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    deserialize_number!(deserialize_i8, visit_i8, i8, "an 8-bit signed integer");
+    deserialize_number!(deserialize_i16, visit_i16, i16, "a 16-bit signed integer");
+    deserialize_number!(deserialize_i32, visit_i32, i32, "a 32-bit signed integer");
+    deserialize_number!(deserialize_i64, visit_i64, i64, "a 64-bit signed integer");
+    deserialize_number!(
+        deserialize_i128,
+        visit_i128,
+        i128,
+        "a 128-bit signed integer"
+    );
+    deserialize_number!(deserialize_u8, visit_u8, u8, "an 8-bit unsigned integer");
+    deserialize_number!(deserialize_u16, visit_u16, u16, "a 16-bit unsigned integer");
+    deserialize_number!(deserialize_u32, visit_u32, u32, "a 32-bit unsigned integer");
+    deserialize_number!(deserialize_u64, visit_u64, u64, "a 64-bit unsigned integer");
+    deserialize_number!(
+        deserialize_u128,
+        visit_u128,
+        u128,
+        "a 128-bit unsigned integer"
+    );
+    deserialize_from_str!(
+        deserialize_f32,
+        visit_f32,
+        f32,
+        "a 32-bit floating point number"
+    );
+    deserialize_from_str!(
+        deserialize_f64,
+        visit_f64,
+        f64,
+        "a 64-bit floating point number"
+    );
+    deserialize_from_str!(deserialize_bool, visit_bool, bool, "a boolean");
+    deserialize_from_str!(deserialize_char, visit_char, char, "a single character");
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::String(value) => visitor.visit_string(value),
+            Self::Array(_) => Err(Self::Error::invalid_type(Unexpected::Seq, &"a string")),
+            Self::Hash(_) => Err(Self::Error::invalid_type(Unexpected::Map, &"a string")),
+            _ => unreachable!(),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Self::Error::UnsupportedType("bytes"))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::BadValue => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::String(value) if value.is_empty() => visitor.visit_unit(),
+            Self::Array(value) if value.is_empty() => visitor.visit_unit(),
+            Self::Hash(value) if value.is_empty() => visitor.visit_unit(),
+            Self::BadValue => visitor.visit_unit(),
+            _ => Err(Self::Error::invalid_value(
+                Unexpected::Other("non-empty node"),
+                &"an empty string, array or map",
+            )),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::String(value) => Err(Self::Error::invalid_type(
+                Unexpected::Str(&value),
+                &"a sequence",
+            )),
+            Self::Array(value) => {
+                let len = value.len();
+                let mut deserializer = ArrayAccess::new(value);
+                let seq = visitor.visit_seq(&mut deserializer)?;
+
+                if deserializer.iter.len() != 0 {
+                    Err(Self::Error::invalid_length(
+                        len,
+                        &"fewer elements in sequence",
+                    ))
+                } else {
+                    Ok(seq)
+                }
+            }
+            Self::Hash(_) => Err(Self::Error::invalid_type(Unexpected::Map, &"a sequence")),
+            _ => unreachable!(),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::String(value) => {
+                Err(Self::Error::invalid_type(Unexpected::Str(&value), &"a map"))
+            }
+            Self::Array(_) => Err(Self::Error::invalid_type(Unexpected::Seq, &"a map")),
+            Self::Hash(value) => {
+                let len = value.len();
+                let mut deserializer = HashAccess::new(value);
+                let seq = visitor.visit_map(&mut deserializer)?;
+
+                if deserializer.iter.len() != 0 {
+                    Err(Self::Error::invalid_length(len, &"fewer elements in map"))
+                } else {
+                    Ok(seq)
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Self::String(variant) => visitor.visit_enum(Enum::new(variant, None)),
+            Self::Array(_) => Err(Self::Error::invalid_type(
+                Unexpected::Seq,
+                &"a map or a string",
+            )),
+            Self::Hash(mut hash) => match hash.pop_front() {
+                Some((variant, value)) => {
+                    visitor.visit_enum(Enum::new(variant.into_string().unwrap(), Some(value)))
+                }
+                _ => Err(Self::Error::invalid_type(Unexpected::Map, &"an enum")),
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+}
+
+struct Enum {
+    variant: String,
+    value: Option<StrictYaml>,
+}
+
+impl<'de> Enum {
+    fn new(variant: String, value: Option<StrictYaml>) -> Self {
+        Self { variant, value }
+    }
+}
+
+impl<'de> EnumAccess<'de> for Enum {
+    type Error = Error;
+    type Variant = Variant;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant =
+            seed.deserialize::<StringDeserializer<Self::Error>>(self.variant.into_deserializer())?;
+        let visitor = Variant { value: self.value };
+        Ok((variant, visitor))
+    }
+}
+
+struct Variant {
+    value: Option<StrictYaml>,
+}
+
+impl<'de> VariantAccess<'de> for Variant {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.value {
+            Some(value) => Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value),
+            None => Err(Self::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(v) => match v {
+                StrictYaml::Array(a) => visitor.visit_seq(ArrayAccess::new(a)),
+                _ => unreachable!(),
+            },
+            None => Err(Self::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(v) => match v {
+                StrictYaml::Hash(h) => visitor.visit_map(HashAccess::new(h)),
+                _ => unreachable!(),
+            },
+            None => Err(Self::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+struct ArrayAccess {
+    iter: vec::IntoIter<StrictYaml>,
+}
+
+impl ArrayAccess {
+    fn new(v: Vec<StrictYaml>) -> Self {
+        Self {
+            iter: v.into_iter(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for ArrayAccess {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct HashAccess {
+    iter: <Hash as IntoIterator>::IntoIter,
+    value: Option<StrictYaml>,
+}
+
+impl HashAccess {
+    fn new(map: Hash) -> Self {
+        Self {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for HashAccess {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                seed.deserialize(key).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(value),
+            None => Err(Self::Error::custom("value is missing")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StrictYaml {
+    fn deserialize<D>(deserializer: D) -> Result<StrictYaml, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrictYamlVisitor;
+
+        impl<'de> Visitor<'de> for StrictYamlVisitor {
+            type Value = StrictYaml;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("any valid StrictYaml value")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(String::from(value))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                Ok(Self::Value::String(value))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = seq.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Self::Value::Array(vec))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut hash = Hash::with_capacity(map.size_hint().unwrap_or_default());
+
+                while let Some((key, value)) = map.next_entry()? {
+                    hash.insert(key, value);
+                }
+
+                Ok(Self::Value::Hash(hash))
+            }
+        }
+
+        deserializer.deserialize_any(StrictYamlVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        serde::{from_str, from_str_many, from_strict_yaml},
+        strict_yaml::{Array, Hash, StrictYaml},
+    };
+    use serde::Deserialize;
+
+    #[test]
+    fn test_primitives() {
+        let input = StrictYaml::String("true".into());
+        assert_eq!(true, from_strict_yaml::<bool>(input).unwrap());
+
+        let input = StrictYaml::String("false".into());
+        assert_eq!(false, from_strict_yaml::<bool>(input).unwrap());
+
+        let input = StrictYaml::String("foobar".into());
+        assert_eq!(
+            "foobar".to_string(),
+            from_strict_yaml::<String>(input).unwrap()
+        );
+
+        let input = StrictYaml::String("100".into());
+        assert_eq!(100, from_strict_yaml::<u16>(input).unwrap());
+
+        let input = StrictYaml::String("-100".into());
+        assert_eq!(-100, from_strict_yaml::<i16>(input).unwrap());
+
+        let input = StrictYaml::String("100".into());
+        assert_eq!(100.0, from_strict_yaml::<f32>(input).unwrap());
+
+        let input = StrictYaml::String("-100.0".into());
+        assert_eq!(-100.0, from_strict_yaml::<f32>(input).unwrap());
+    }
+
+    #[test]
+    fn test_option() {
+        let input = StrictYaml::String("foobar".into());
+        assert_eq!(
+            Some("foobar".to_string()),
+            from_strict_yaml::<Option<String>>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_unit() {
+        let input = StrictYaml::String(String::new());
+        assert_eq!((), from_strict_yaml::<()>(input).unwrap());
+
+        let input = StrictYaml::Array(Array::new());
+        assert_eq!((), from_strict_yaml::<()>(input).unwrap());
+
+        let input = StrictYaml::Hash(Hash::new());
+        assert_eq!((), from_strict_yaml::<()>(input).unwrap());
+    }
+
+    #[test]
+    fn test_unit_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test;
+
+        let input = StrictYaml::String(String::new());
+
+        assert_eq!(Test, from_strict_yaml::<Test>(input).unwrap());
+    }
+
+    #[test]
+    fn test_newtype_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test(String);
+
+        let input = StrictYaml::String("foobar".into());
+
+        assert_eq!(
+            Test("foobar".to_string()),
+            from_strict_yaml::<Test>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_seq() {
+        let input = StrictYaml::Array(vec![
+            StrictYaml::String("10".into()),
+            StrictYaml::String("20".into()),
+            StrictYaml::String("30".into()),
+        ]);
+
+        assert_eq!(
+            vec![10, 20, 30],
+            from_strict_yaml::<Vec<u16>>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_tuple() {
+        let input = StrictYaml::Array(vec![
+            StrictYaml::String("10".into()),
+            StrictYaml::String("20".into()),
+            StrictYaml::String("30".into()),
+        ]);
+
+        assert_eq!(
+            (10, 20, 30),
+            from_strict_yaml::<(u16, u16, u16)>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_tuple_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test(String, bool, u8);
+
+        let input = StrictYaml::Array(vec![
+            StrictYaml::String("foobar".into()),
+            StrictYaml::String("true".into()),
+            StrictYaml::String("20".into()),
+        ]);
+
+        assert_eq!(
+            Test("foobar".to_string(), true, 20),
+            from_strict_yaml::<Test>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test {
+            a: bool,
+            b: String,
+            c: i64,
+            d: f64,
+        }
+
+        let mut hash = Hash::new();
+
+        hash.insert(
+            StrictYaml::String("a".into()),
+            StrictYaml::String("true".into()),
+        );
+
+        hash.insert(
+            StrictYaml::String("c".into()),
+            StrictYaml::String("10".into()),
+        );
+
+        hash.insert(
+            StrictYaml::String("d".into()),
+            StrictYaml::String("10.0".into()),
+        );
+
+        hash.insert(
+            StrictYaml::String("b".into()),
+            StrictYaml::String("foobar".into()),
+        );
+
+        let input = StrictYaml::Hash(hash);
+
+        let expected = Test {
+            a: true,
+            b: "foobar".to_string(),
+            c: 10,
+            d: 10.0,
+        };
+
+        assert_eq!(expected, from_strict_yaml::<Test>(input).unwrap());
+    }
+
+    #[test]
+    fn test_deserialize_any_from_str() {
+        let input = r#"
+---
+foobar
+"#;
+
+        assert_eq!(
+            StrictYaml::String("foobar".into()),
+            from_str::<StrictYaml>(input).unwrap()
+        );
+
+        let input = r#"
+---
+- foo
+- bar
+- baz
+...
+"#;
+
+        assert_eq!(
+            StrictYaml::Array(vec![
+                StrictYaml::String("foo".into()),
+                StrictYaml::String("bar".into()),
+                StrictYaml::String("baz".into()),
+            ]),
+            from_str::<StrictYaml>(input).unwrap()
+        );
+
+        let input = r#"
+---
+foo: bar
+10: 20
+true: false
+...
+"#;
+
+        let mut hash = Hash::new();
+        hash.insert(
+            StrictYaml::String("foo".into()),
+            StrictYaml::String("bar".into()),
+        );
+        hash.insert(
+            StrictYaml::String("10".into()),
+            StrictYaml::String("20".into()),
+        );
+        hash.insert(
+            StrictYaml::String("true".into()),
+            StrictYaml::String("false".into()),
+        );
+
+        assert_eq!(
+            StrictYaml::Hash(hash),
+            from_str::<StrictYaml>(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_deserialize_any_from_str_many() {
+        let input = r#"
+---
+foo
+...
+---
+bar
+---
+baz
+...
+"#;
+
+        assert_eq!(
+            vec![
+                StrictYaml::String("foo".into()),
+                StrictYaml::String("bar".into()),
+                StrictYaml::String("baz".into())
+            ],
+            from_str_many::<Vec<StrictYaml>>(input).unwrap()
+        );
+    }
+}

--- a/src/strict_yaml/serde/mod.rs
+++ b/src/strict_yaml/serde/mod.rs
@@ -1,0 +1,2 @@
+mod de;
+pub(crate) mod ser;

--- a/src/strict_yaml/serde/ser.rs
+++ b/src/strict_yaml/serde/ser.rs
@@ -1,0 +1,480 @@
+use crate::{
+    serde::error::Error,
+    strict_yaml::{Hash, StrictYaml},
+};
+use serde::ser::{
+    self, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+};
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    type SerializeSeq = SerializeArray;
+    type SerializeTuple = SerializeArray;
+    type SerializeTupleStruct = SerializeArray;
+    type SerializeTupleVariant = SerializeArray;
+    type SerializeMap = SerializeHash;
+    type SerializeStruct = SerializeHash;
+    type SerializeStructVariant = SerializeHash;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(v.to_string()))
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(String::new()))
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_none()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let array = match len {
+            None => Vec::new(),
+            Some(len) => Vec::with_capacity(len),
+        };
+
+        Ok(SerializeArray { array })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let hash = match len {
+            None => Hash::new(),
+            Some(len) => Hash::with_capacity(len),
+        };
+
+        Ok(SerializeHash { hash, key: None })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        let key = variant.serialize(self)?;
+        Ok(SerializeHash {
+            hash: Hash::with_capacity(len),
+            key: Some(key),
+        })
+    }
+}
+
+pub struct SerializeArray {
+    array: Vec<StrictYaml>,
+}
+
+impl SerializeSeq for SerializeArray {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, elem: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.array.push(elem.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Array(self.array))
+    }
+}
+
+impl SerializeTuple for SerializeArray {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, elem: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.array.push(elem.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Array(self.array))
+    }
+}
+
+impl SerializeTupleStruct for SerializeArray {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, elem: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.array.push(elem.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Array(self.array))
+    }
+}
+
+impl SerializeTupleVariant for SerializeArray {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, elem: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.array.push(elem.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Array(self.array))
+    }
+}
+
+pub struct SerializeHash {
+    hash: Hash,
+    key: Option<StrictYaml>,
+}
+
+impl SerializeMap for SerializeHash {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.key = Some(key.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let value = value.serialize(Serializer)?;
+
+        match self.key.take() {
+            Some(key) => self.hash.insert(key, value),
+            None => {
+                return Err(Error::Message(
+                    "serialize_value called before serialize_key".to_string(),
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Hash(self.hash))
+    }
+}
+
+impl SerializeStruct for SerializeHash {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let key = key.serialize(Serializer)?;
+        let value = value.serialize(Serializer)?;
+
+        self.hash.insert(key, value);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Hash(self.hash))
+    }
+}
+
+impl SerializeStructVariant for SerializeHash {
+    type Ok = StrictYaml;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = key.serialize(Serializer)?;
+        let value = value.serialize(Serializer)?;
+
+        self.hash.insert(key, value);
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Hash(self.hash))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{serde::to_strict_yaml, strict_yaml::StrictYaml};
+    use serde::Serialize;
+
+    #[test]
+    fn test_primitives() {
+        let input = "foobar";
+
+        let yaml = StrictYaml::String(input.to_string());
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+
+        let input = true;
+
+        let yaml = StrictYaml::String(input.to_string());
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+
+        let input = 100;
+
+        let yaml = StrictYaml::String(input.to_string());
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+
+        let input = 100.0;
+
+        let yaml = StrictYaml::String(input.to_string());
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+    }
+
+    #[test]
+    fn test_none() {
+        assert_eq!(
+            to_strict_yaml(None::<Vec<u8>>).unwrap(),
+            StrictYaml::String("".into())
+        );
+    }
+
+    #[test]
+    fn test_some() {
+        assert_eq!(
+            to_strict_yaml(Some(true)).unwrap(),
+            StrictYaml::String("true".into())
+        );
+    }
+
+    #[test]
+    fn test_unit() {
+        assert_eq!(to_strict_yaml(()).unwrap(), StrictYaml::String("".into()));
+    }
+
+    #[test]
+    fn test_unit_variant() {
+        #[derive(Serialize)]
+        enum Test {
+            Foobar,
+        }
+
+        assert_eq!(
+            to_strict_yaml(Test::Foobar).unwrap(),
+            StrictYaml::String("Foobar".into())
+        );
+    }
+
+    #[test]
+    fn test_newtype_struct() {
+        #[derive(Serialize)]
+        struct Test(bool);
+
+        assert_eq!(
+            to_strict_yaml(Test(true)).unwrap(),
+            StrictYaml::String("true".into())
+        );
+    }
+
+    #[test]
+    fn test_newtype_variant() {
+        #[derive(Serialize)]
+        enum Test {
+            Foobar(bool),
+        }
+
+        assert_eq!(
+            to_strict_yaml(Test::Foobar(true)).unwrap(),
+            StrictYaml::String("true".into())
+        );
+    }
+
+    #[test]
+    fn test_seq() {
+        let input = vec![1, 2, 3];
+
+        let yaml = StrictYaml::Array(vec![
+            StrictYaml::String("1".into()),
+            StrictYaml::String("2".into()),
+            StrictYaml::String("3".into()),
+        ]);
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+    }
+
+    #[test]
+    fn test_tuple() {
+        let input = (1, true, "foobar");
+
+        let yaml = StrictYaml::Array(vec![
+            StrictYaml::String("1".into()),
+            StrictYaml::String("true".into()),
+            StrictYaml::String("foobar".into()),
+        ]);
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+    }
+
+    #[test]
+    fn test_tuple_struct() {
+        #[derive(Serialize)]
+        struct Test(u8, bool, &'static str);
+
+        let input = Test(1, true, "foobar");
+
+        let yaml = StrictYaml::Array(vec![
+            StrictYaml::String("1".into()),
+            StrictYaml::String("true".into()),
+            StrictYaml::String("foobar".into()),
+        ]);
+
+        assert_eq!(to_strict_yaml(input).unwrap(), yaml);
+    }
+}


### PR DESCRIPTION
Hey there,

this PR tackles #5 and adds a serde implementation. From the squashed commit:

* adds an optional feature `serde`
* adds functions in the new `serde` mod with proper exports as per [convention](https://serde.rs/conventions.html)
* adds `Deserializer` and `Serializer` that re-use `StrictYamlLoader` and `StrictYamlEmitter` as best as possible
* adds `Deserializer` and `Serializer` impls to `StrictYaml` to convert from/to other types
* adds `pub(crate)` to types that are part of the current API and can be re-used by the serde impls

Some caveats that probably need looking at:

* unlike `serde_json` I chose not to implement `Iterator` for the deserializer to deserialize multi-document streams, but instead take advantage of the fact that sequence types such as `Vec` implement `Deserialize` and `Serialize` and enable different behaviour via the `from_str` and `from_str_many` functions (same for serialization). But the `Iterator` based API might fit better here. Would love some input on this topic.
* deserialization errors might not be ideal. For example it says: `invalid value: string "2.0", expected an 8-bit unsigned integer at line 7` when I try to deserialize a `u8` from the scalar `2.0`. It might be better to use a different [`Unexpected`](https://docs.rs/serde/latest/serde/de/enum.Unexpected.html) here.
* I tried to test thoroughly but I am not confident that there aren't some combinations of nested maps/arrays/scalars that lead to unexpected results.

Happy reviewing!