### PR TITLE
Fix rust docs to display opt. features, update README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "strict-yaml-rust"
 version = "0.2.0"
 edition = "2024"
 authors = ["Yuheng Chen <yuhengchen@sensetime.com>", "Francis Lalonde <fralalonde@gmail.com>"]
-homepage = "http://fralalonde.github.io/strict-yaml-rust/"
 documentation = "https://docs.rs/crate/strict-yaml-rust/"
 license = "MIT/Apache-2.0"
 description = "A StrictYAML parser obtained by savagely chopping up the original yaml-rust crate."
@@ -20,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 
 [features]
 serde = ["dep:serde", "linked-hash-map/serde_impl"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add the following to the Cargo.toml of your project:
 
 ```toml
 [dependencies]
-strict-yaml-rust = "0.1"
+strict-yaml-rust = "0.2"
 ```
 
 or


### PR DESCRIPTION
Hello,

I noticed that the `serde` module does not yet show up on [docs.rs](https://docs.rs/strict-yaml-rust/latest/strict_yaml_rust/index.html). This depends on an extra setting in `Cargo.toml` to work as per [the docs](https://docs.rs/about/metadata).

Also took the liberty of removing a broken link and bumping the version in the README.

Cheers!